### PR TITLE
README: Add link to the intellij-emberjs project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 EmberJS IntelliJ plugin
 =======================
 
+__WARNING:__ This project is obsolete. Checkout the new [intellij-emberjs](https://github.com/Turbo87/intellij-emberjs) project instead which implemented a lot of the same ideas and is based on the `ember-cli` conventions!
+
 EmberJS Support for the Intellij Platform (WebStorm, PhpStorm, Rubymine, Intellij, etc).
 
 This is still very much a Work In Progress. Please help make this a great plugin!!!


### PR DESCRIPTION
This PR adds a warning to the Readme about this project being largely unmaintained and a link to the "successor" project at https://github.com/Turbo87/intellij-emberjs

I hope you don't feel bad about me starting from scratch with the other plugin, but due to the large time gap I felt it was not worth the extra work of making this one work first in its current form. 
